### PR TITLE
Avoid passing `pyproject.toml` to Ruff's server

### DIFF
--- a/src/main/kotlin/insyncwithfoo/ryecharm/KnownFiles.kt
+++ b/src/main/kotlin/insyncwithfoo/ryecharm/KnownFiles.kt
@@ -138,6 +138,14 @@ internal fun VirtualFile.canBeLintedByRuff(project: Project? = null): Boolean {
 
 
 /**
+ * Whether the given file can be handled by Ruff's server.
+ Currently it only expects Python files.
+ */
+internal val VirtualFile.isExpectedByRuffServer: Boolean
+    get() = isPythonFile
+
+
+/**
  * Whether the given file can be formatted by Ruff's formatter.
  */
 internal fun VirtualFile.canBeFormattedByRuff(project: Project? = null): Boolean {

--- a/src/main/kotlin/insyncwithfoo/ryecharm/ruff/lsp/RuffServerDescriptor.kt
+++ b/src/main/kotlin/insyncwithfoo/ryecharm/ruff/lsp/RuffServerDescriptor.kt
@@ -4,10 +4,9 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
-import insyncwithfoo.ryecharm.canBeLintedByRuff
 import insyncwithfoo.ryecharm.common.logging.ruffLogger
 import insyncwithfoo.ryecharm.configurations.ruff.ruffConfigurations
-import insyncwithfoo.ryecharm.isPyprojectToml
+import insyncwithfoo.ryecharm.isExpectedByRuffServer
 import insyncwithfoo.ryecharm.message
 import insyncwithfoo.ryecharm.path
 import insyncwithfoo.ryecharm.ruff.createInitializationOptionsObject
@@ -45,7 +44,7 @@ internal class RuffServerDescriptor(project: Project, private val executable: Pa
      * are ignored by the client.
      */
     override fun isSupportedFile(file: VirtualFile) =
-        file.canBeLintedByRuff(project) && !file.isPyprojectToml
+        file.isExpectedByRuffServer
     
     override fun createInitializationOptions() =
         project.createInitializationOptionsObject().also {


### PR DESCRIPTION
Resolves #67.